### PR TITLE
 Set favourite locale of user for tour on home-page

### DIFF
--- a/pontoon/base/templates/home.html
+++ b/pontoon/base/templates/home.html
@@ -28,7 +28,7 @@
             <div>Start Localizing Now</div>
           </a>
           <p class="flex-col-full">or</p>
-          <a class="flex-col-full homepage-button secondary-button-cta" href="/tour/">
+          <a class="flex-col-full homepage-button secondary-button-cta" href="/{{ locale }}/demo/database/">
             <div>Take a Tour</div>
           </a>
         </div>
@@ -146,7 +146,7 @@
           <div>Start Localizing Now</div>
         </a>
         <p class="content-style">Want to learn more?</p>
-        <a class="homepage-button secondary-button-cta" href="/tour/">
+        <a class="homepage-button secondary-button-cta" href="/{{ locale }}/demo/database/">
           <div>Take a Tour</div>
         </a>
       </div>


### PR DESCRIPTION
The link for the tour which will be available through the CTA needs a language(locale) to be chosen. 
So for this, I guess using either `top_contributed_locale` for an authenticated user or `utils.get_project_locale_from_request` might be the way to go. 
 